### PR TITLE
Update theme for EatSmart

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Asha AI by JobsForHer",
+  title: "EatSmart Chatbot",
 };
 
 import { AppSidebar } from "@/components/app-sidebar";

--- a/app/globals.css
+++ b/app/globals.css
@@ -50,92 +50,73 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.823);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.55 0.15 145);
-  /* JobsForHer green */
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.55 0.15 145);
-  /* JobsForHer green */
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.6 0.18 300);
-  /* JobsForHer purple */
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.637 0.237 25.331);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.871 0.006 286.286);
-  --ring: oklch(0.55 0.15 145);
-  /* JobsForHer green */
-  --chart-1: oklch(0.55 0.15 145);
-  /* JobsForHer green */
-  --chart-2: oklch(0.6 0.18 300);
-  /* JobsForHer purple */
-  --chart-3: oklch(0.65 0.12 132);
-  /* Lighter green */
-  --chart-4: oklch(0.55 0.2 280);
-  /* Lighter purple */
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.21 0.006 285.885);
-  --sidebar-foreground: oklch(0.871 0.006 286.286);
-  --sidebar-primary: oklch(0.55 0.15 145);
-  /* JobsForHer green */
-  --sidebar-primary-foreground: oklch(0.871 0.006 286.286);
-  --sidebar-accent: oklch(0.6 0.18 300);
-  /* JobsForHer purple */
-  --sidebar-accent-foreground: oklch(0.871 0.006 286.286);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.871 0.006 286.286);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --background: #1E2A44;
+  --foreground: #FFFFFF;
+  --card: #2D3B55;
+  --card-foreground: #FFFFFF;
+  --popover: #2D3B55;
+  --popover-foreground: #FFFFFF;
+  --primary: #3B82F6;
+  --primary-foreground: #FFFFFF;
+  --secondary: #2DD4BF;
+  --secondary-foreground: #1E2A44;
+  --muted: #3F4E73;
+  --muted-foreground: #93C5FD;
+  --accent: #2DD4BF;
+  --accent-foreground: #FFFFFF;
+  --destructive: #EF4444;
+  --border: #4B5EAA;
+  --input: #4B5EAA;
+  --ring: #3B82F6;
+  --chart-1: #3B82F6;
+  --chart-2: #2DD4BF;
+  --chart-3: #BFDBFE;
+  --chart-4: #4B5EAA;
+  --chart-5: #1E40AF;
+  --sidebar: #2D3B55;
+  --sidebar-foreground: #FFFFFF;
+  --sidebar-primary: #3B82F6;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #2DD4BF;
+  --sidebar-accent-foreground: #1E2A44;
+  --sidebar-border: #4B5EAA;
+  --sidebar-ring: #3B82F6;
+  --destructive-foreground: #FFFFFF;
 }
 
 .dark {
-  --background: oklch(0.21 0.006 285.885);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.65 0.15 145);
-  /* JobsForHer green - brighter for dark mode */
-  --primary-foreground: oklch(0.21 0.006 285.885);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.65 0.18 300);
-  /* JobsForHer purple - brighter for dark mode */
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.637 0.237 25.331);
-  --border: oklch(0.274 0.006 286.033);
-  --input: oklch(0.274 0.006 286.033);
-  --ring: oklch(0.65 0.15 145);
-  /* JobsForHer green - brighter for dark mode */
-  --chart-1: oklch(0.65 0.15 145);
-  /* JobsForHer green - brighter for dark mode */
-  --chart-2: oklch(0.65 0.18 300);
-  /* JobsForHer purple - brighter for dark mode */
-  --chart-3: oklch(0.75 0.12 132);
-  /* Lighter green */
-  --chart-4: oklch(0.7 0.2 280);
-  /* Lighter purple */
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.21 0.006 285.885);
-  --sidebar-foreground: oklch(0.871 0.006 286.286);
-  --sidebar-primary: oklch(0.65 0.15 145);
-  /* JobsForHer green - brighter for dark mode */
-  --sidebar-primary-foreground: oklch(0.871 0.006 286.286);
-  --sidebar-accent: oklch(0.65 0.18 300);
-  /* JobsForHer purple - brighter for dark mode */
-  --sidebar-accent-foreground: oklch(0.871 0.006 286.286);
-  --sidebar-border: oklch(0.274 0.006 286.033);
-  --sidebar-ring: oklch(0.442 0.017 285.786);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --background: #1E2A44;
+  --foreground: #FFFFFF;
+  --card: #2D3B55;
+  --card-foreground: #FFFFFF;
+  --popover: #2D3B55;
+  --popover-foreground: #FFFFFF;
+  --primary: #3B82F6;
+  --primary-foreground: #FFFFFF;
+  --secondary: #2DD4BF;
+  --secondary-foreground: #1E2A44;
+  --muted: #3F4E73;
+  --muted-foreground: #93C5FD;
+  --accent: #2DD4BF;
+  --accent-foreground: #FFFFFF;
+  --destructive: #EF4444;
+  --border: #4B5EAA;
+  --input: #4B5EAA;
+  --ring: #3B82F6;
+  --chart-1: #3B82F6;
+  --chart-2: #2DD4BF;
+  --chart-3: #BFDBFE;
+  --chart-4: #4B5EAA;
+  --chart-5: #1E40AF;
+  --sidebar: #2D3B55;
+  --sidebar-foreground: #FFFFFF;
+  --sidebar-primary: #3B82F6;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #2DD4BF;
+  --sidebar-accent-foreground: #1E2A44;
+  --sidebar-border: #4B5EAA;
+  --sidebar-ring: #3B82F6;
+  --destructive-foreground: #FFFFFF;
 }
 
 @layer base {
@@ -145,7 +126,7 @@
 
   body {
     @apply bg-background text-foreground;
-    background-image: url("data:image/svg+xml,%3Csvg width='100' height='100' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 18c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm48 25c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm-43-7c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm63 31c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM34 90c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm56-76c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM12 86c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm28-65c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm23-11c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-6 60c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm29 22c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zM32 63c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm57-13c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-9-21c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM60 91c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM35 41c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM12 60c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2z' fill='rgba(130, 71, 200, 0.05)' fill-rule='evenodd'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg width='50' height='50' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 2c1.1 2.5 3 4 5 4-1 1-2 3-2 5 0-2-1-4-3-5-2 1-3 3-3 5 0-2-1-4-2-5 2 0 4-1.5 5-4z' fill='%23ffffff' fill-opacity='0.05'/%3E%3C/svg%3E");
   }
 
   /* Add smoother transitions for interactive elements */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,12 +8,12 @@ const fontSans = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "Asha AI by JobsForHer",
-  description: "AI-powered virtual assistant for women's career growth, job discovery, and professional networking. Get personalized guidance on job listings, community events, mentorship programs, and career development resources.",
-  keywords: ["women careers", "job search", "career growth", "mentorship", "professional networking", "AI assistant", "career guidance", "women empowerment"],
-  authors: [{ name: "JobsForHer Foundation" }],
-  creator: "JobsForHer Foundation",
-  publisher: "JobsForHer Foundation",
+  title: "EatSmart Chatbot",
+  description: "AI-powered assistant to help you make healthier food choices by scanning packaged foods and providing dietary alerts.",
+  keywords: ["nutrition", "food scanner", "diet alerts", "healthy eating", "AI assistant"],
+  authors: [{ name: "EatSmart" }],
+  creator: "EatSmart",
+  publisher: "EatSmart",
   robots: "index, follow",
   viewport: "width=device-width, initial-scale=1",
   themeColor: "#ffffff",
@@ -23,16 +23,16 @@ export const metadata: Metadata = {
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://jobsforher.com",
-    title: "Asha AI by JobsForHer",
-    description: "AI-powered virtual assistant for women's career growth and professional development",
-    siteName: "JobsForHer",
+    url: "https://eatsmart.app",
+    title: "EatSmart Chatbot",
+    description: "AI-powered assistant for healthier food choices",
+    siteName: "EatSmart",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Asha AI by JobsForHer",
-    description: "AI-powered virtual assistant for women's career growth and professional development",
-    creator: "@jobsforher",
+    title: "EatSmart Chatbot",
+    description: "AI-powered assistant for healthier food choices",
+    creator: "@eatsmart",
   },
 };
 

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -40,7 +40,7 @@ import { Button } from "@/components/ui/button";
 const data = {
   teams: [
     {
-      name: "Asha AI by JobsForHer",
+      name: "EatSmart Chatbot",
       logo: "https://res.cloudinary.com/dlzlfasou/image/upload/v1741345635/logo-01_upxvqe.png",
     },
     {
@@ -72,7 +72,7 @@ const data = {
   ],
   navMain: [
     {
-      title: "ASHA AI",
+      title: "EatSmart",
       url: "#",
       items: [
         {

--- a/components/chat-message.tsx
+++ b/components/chat-message.tsx
@@ -102,18 +102,20 @@ export function ChatMessage({ isUser, children }: ChatMessageProps) {
             ? "https://res.cloudinary.com/dlzlfasou/image/upload/v1741345634/user-02_mlqqqt.png"
             : "https://res.cloudinary.com/dlzlfasou/image/upload/v1741345634/user-01_i5l7tp.png"
         }
-        alt={isUser ? "User profile" : "Asha AI logo"}
+        alt={isUser ? "User profile" : "EatSmart logo"}
         width={40}
         height={40}
       />
       <div
         className={cn(
           "chat-message",
-          isUser ? "bg-muted px-4 py-3 rounded-xl" : "space-y-4"
+          isUser
+            ? "bg-[#BFDBFE] text-white px-4 py-3 rounded-xl"
+            : "bg-[#3F4E73] border border-[#4B5EAA] px-4 py-3 rounded-xl space-y-4"
         )}
       >
         <div className="flex flex-col gap-3">
-          <p className="sr-only">{isUser ? "You" : "Asha AI"} said:</p>
+          <p className="sr-only">{isUser ? "You" : "EatSmart"} said:</p>
           {React.Children.map(children, child => renderContent(child))}
         </div>
         {!isUser && (

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -22,6 +22,9 @@ import {
   RiFileList3Line,
   RiUserStarLine,
   RiWomenLine,
+  RiQrScan2Line,
+  RiAlertLine,
+  RiSettings4Line,
 } from "@remixicon/react";
 import { ChatMessage } from "@/components/chat-message";
 import { useRef, useEffect, useState } from "react";
@@ -140,7 +143,7 @@ export default function Chat({ className, assistantId, sampleQuestions }: ChatPr
     } catch (err: any) {
       console.error("Failed to fetch AI response:", err);
       setIsLoading(false);
-      setError(err.message || "Failed to get response from Asha AI.");
+      setError(err.message || "Failed to get response from EatSmart.");
       setMessages(prev => [
         ...prev,
         {
@@ -160,15 +163,15 @@ export default function Chat({ className, assistantId, sampleQuestions }: ChatPr
   };
 
   return (
-    <ScrollArea className="flex-1 [&>div>div]:h-full w-full shadow-md md:rounded-s-[inherit] min-[1024px]:rounded-e-3xl bg-background">
+    <ScrollArea className="flex-1 [&>div>div]:h-full w-full shadow-md md:rounded-s-[inherit] min-[1024px]:rounded-e-3xl bg-[#2D3B55]">
       <div className="h-full flex flex-col px-4 md:px-6 lg:px-8">
         {/* Header */}
-        <div className="py-5 bg-background sticky top-0 z-10 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-gradient-to-r before:from-black/[0.06] before:via-black/10 before:to-black/[0.06]">
+        <div className="py-5 bg-[#172033] sticky top-0 z-10 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-gradient-to-r before:from-black/[0.06] before:via-black/10 before:to-black/[0.06]">
           <div className="flex items-center justify-between gap-2">
             <Breadcrumb>
               <BreadcrumbList className="sm:gap-1.5">
                 <BreadcrumbItem>
-                  <BreadcrumbPage>Asha AI by JobsForHer</BreadcrumbPage>
+                  <BreadcrumbPage>EatSmart Chatbot</BreadcrumbPage>
                 </BreadcrumbItem>
               </BreadcrumbList>
             </Breadcrumb>
@@ -199,51 +202,35 @@ export default function Chat({ className, assistantId, sampleQuestions }: ChatPr
           {!chatSelected && messages.length === 0 ? (
             <div className="max-w-3xl mx-auto mt-6 flex flex-col items-center justify-center h-[calc(100%-120px)]">
               <div className="text-center mb-8">
-                <h1 className="text-2xl font-semibold mb-6">How can I help with your career journey?</h1>
+                <h1 className="text-2xl font-semibold mb-6">How can I help you eat smarter today?</h1>
                 <p className="text-muted-foreground">
-                  Asha AI is here to assist you with job discovery, career advice, and professional networking.
+                  EatSmart helps you scan packaged foods and get personalized health insights.
                 </p>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3 w-full max-w-xl">
                 <Button
                   variant="outline"
-                  className="flex items-center justify-start gap-2 h-14 px-4 hover:bg-background/80 hover:border-primary/50 transition-all hover:text-black"
-                  onClick={() => handleSuggestionClick("Find jobs in my field")}
+                  className="flex items-center justify-start gap-2 h-14 px-4 hover:bg-background/80 hover:border-primary/50 transition-all hover:text-white"
+                  onClick={() => handleSuggestionClick("Start a new scan")}
                 >
-                  <RiFileChartLine className="text-primary" size={20} />
-                  <span>Find jobs in my field</span>
+                  <RiQrScan2Line className="text-primary" size={20} />
+                  <span>New Scan</span>
                 </Button>
                 <Button
                   variant="outline"
-                  className="flex items-center justify-start gap-2 h-14 px-4 hover:bg-background/80 hover:border-primary/50 transition-all hover:text-black"
-                  onClick={() => handleSuggestionClick("Upcoming career events")}
+                  className="flex items-center justify-start gap-2 h-14 px-4 hover:bg-background/80 hover:border-primary/50 transition-all hover:text-white"
+                  onClick={() => handleSuggestionClick("Show my alerts")}
                 >
-                  <RiCalendarEventLine className="text-primary" size={20} />
-                  <span>Upcoming career events</span>
+                  <RiAlertLine className="text-primary" size={20} />
+                  <span>View Alerts</span>
                 </Button>
                 <Button
                   variant="outline"
-                  className="flex items-center justify-start gap-2 h-14 px-4 hover:bg-background/80 hover:border-primary/50 transition-all hover:text-black "
-                  onClick={() => handleSuggestionClick("Resume improvement tips")}
+                  className="flex items-center justify-start gap-2 h-14 px-4 hover:bg-background/80 hover:border-primary/50 transition-all hover:text-white col-span-1 md:col-span-2"
+                  onClick={() => handleSuggestionClick("Open settings")}
                 >
-                  <RiFileList3Line className="text-primary" size={20} />
-                  <span>Resume improvement tips</span>
-                </Button>
-                <Button
-                  variant="outline"
-                  className="flex items-center justify-start gap-2 h-14 px-4 hover:bg-background/80 hover:border-primary/50 transition-all hover:text-black"
-                  onClick={() => handleSuggestionClick("Mentorship opportunities")}
-                >
-                  <RiUserStarLine className="text-primary" size={20} />
-                  <span>Mentorship opportunities</span>
-                </Button>
-                <Button
-                  variant="outline"
-                  className="flex items-center justify-start gap-2 h-14 px-4 hover:bg-background/80 hover:border-primary/50 transition-all hover:text-black col-span-1 md:col-span-2"
-                  onClick={() => handleSuggestionClick("Women in tech resources")}
-                >
-                  <RiWomenLine className="text-primary" size={20} />
-                  <span>Women in tech resources</span>
+                  <RiSettings4Line className="text-primary" size={20} />
+                  <span>Settings</span>
                 </Button>
               </div>
             </div>
@@ -291,7 +278,7 @@ export default function Chat({ className, assistantId, sampleQuestions }: ChatPr
                   <img
                     className="rounded-full border border-black/[0.08] shadow-sm"
                     src="https://res.cloudinary.com/dlzlfasou/image/upload/v1741345634/user-01_i5l7tp.png"
-                    alt="Asha AI"
+                    alt="EatSmart"
                     width={40}
                     height={40}
                   />
@@ -317,7 +304,7 @@ export default function Chat({ className, assistantId, sampleQuestions }: ChatPr
 
         {/* Footer */}
         <div className="sticky bottom-0 pt-4 md:pt-8 z-50">
-          <div className="max-w-3xl mx-auto bg-background rounded-[20px] pb-4 md:pb-8">
+          <div className="max-w-3xl mx-auto bg-[#2D3B55] rounded-[20px] pb-4 md:pb-8">
             <div className="relative rounded-[20px] border border-transparent bg-muted transition-colors focus-within:bg-muted/50 focus-within:border-input has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50 [&:has(input:is(:disabled))_*]:pointer-events-none">
               <textarea
                 className="flex sm:min-h-[84px] w-full bg-transparent px-4 py-3 text-[15px] leading-relaxed text-foreground placeholder:text-muted-foreground/70 focus-visible:outline-none [resize:none]"
@@ -341,33 +328,33 @@ export default function Chat({ className, assistantId, sampleQuestions }: ChatPr
                     size="sm"
                     className="rounded-full border-none hover:bg-background/80 hover:text-foreground hover:shadow-sm transition-all"
                   >
-                    <RiEyeLine
+                    <RiQrScan2Line
                       className="text-muted-foreground/70 size-4 mr-1"
                       aria-hidden="true"
                     />
-                    <span>View Feed</span>
+                    <span>New Scan</span>
                   </Button>
                   <Button
                     variant="outline"
                     size="sm"
                     className="rounded-full border-none hover:bg-background/80 hover:text-foreground hover:shadow-sm transition-all"
                   >
-                    <RiUserFollowLine
+                    <RiAlertLine
                       className="text-muted-foreground/70 size-4 mr-1"
                       aria-hidden="true"
                     />
-                    <span>Signup Help</span>
+                    <span>View Alerts</span>
                   </Button>
                   <Button
                     variant="outline"
                     size="sm"
                     className="rounded-full border-none hover:bg-background/80 hover:text-foreground hover:shadow-sm transition-all"
                   >
-                    <RiQuestionLine
+                    <RiSettings4Line
                       className="text-muted-foreground/70 size-4 mr-1"
                       aria-hidden="true"
                     />
-                    <span>FAQs</span>
+                    <span>Settings</span>
                   </Button>
                 </div>
                 {/* Right buttons */}
@@ -377,7 +364,7 @@ export default function Chat({ className, assistantId, sampleQuestions }: ChatPr
                     onClick={handleSendMessage}
                     disabled={!inputValue.trim() || isLoading} // Disable while typing
                   >
-                    <span>Ask AshaAI</span>
+                    <span>Ask EatSmart</span>
                     <RiSendPlaneFill size={16} />
                   </Button>
                 </div>


### PR DESCRIPTION
## Summary
- switch brand references from Asha AI to EatSmart
- overhaul global color variables for a dark bluish palette
- update chat messages and quick actions to match EatSmart UI
- adjust sidebar and metadata branding

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684da37539848321bae0027ecd4eb1df